### PR TITLE
Update interrupt cosim support + generalize CLINT read/write

### DIFF
--- a/src/dromajo_cosim.cpp
+++ b/src/dromajo_cosim.cpp
@@ -290,14 +290,15 @@ int dromajo_cosim_step(dromajo_cosim_state_t *state,
         if (r->common.pending_interrupt != -1)
             riscv_cpu_set_mip(s, riscv_cpu_get_mip(s) | 1 << r->common.pending_interrupt);
 
-        r->common.pending_interrupt = -1;
-        r->common.pending_exception = -1;
-
         if (riscv_cpu_interp64(s, 1) != 0) {
             iregno = riscv_get_most_recently_written_reg(s);
             fregno = riscv_get_most_recently_written_fp_reg(s);
             break;
         }
+
+        r->common.pending_interrupt = -1;
+        r->common.pending_exception = -1;
+
     }
 
     if (check)

--- a/src/dromajo_template.h
+++ b/src/dromajo_template.h
@@ -262,7 +262,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles)
     insn_counter_addend = s->insn_counter + n_cycles;
 
     /* check pending interrupts */
-    if (unlikely((s->mip & s->mie) != 0)) {
+    if (unlikely(((s->mip & s->mie) != 0) && (s->machine->common.pending_interrupt != -1))) {
         if (raise_interrupt(s)) {
             --insn_counter_addend;
             goto done_interp;
@@ -307,7 +307,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles)
             target_ulong addr;
 
             /* check pending interrupts */
-            if (unlikely((s->mip & s->mie) != 0)) {
+            if (unlikely(((s->mip & s->mie) != 0) && (s->machine->common.pending_interrupt != -1))) {
                 if (raise_interrupt(s)) {
                     goto the_end;
                 }
@@ -1436,7 +1436,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles)
                         goto illegal_insn;
                     /* go to power down if no enabled interrupts are
                        pending */
-                    if ((s->mip & s->mie) == 0) {
+                    if (((s->mip & s->mie) == 0) && (s->machine->common.pending_interrupt == -1)) {
                         s->power_down_flag = TRUE;
                         s->pc = GET_PC() + 4;
                         goto done_interp;

--- a/src/riscv_cpu.cpp
+++ b/src/riscv_cpu.cpp
@@ -1851,7 +1851,7 @@ void riscv_cpu_set_mip(RISCVCPUState *s, uint32_t mask)
 {
     s->mip |= mask;
     /* exit from power down if an interrupt is pending */
-    if (s->power_down_flag && (s->mip & s->mie) != 0)
+    if (s->power_down_flag && (s->mip & s->mie) != 0 && (s->machine->common.pending_interrupt != -1))
         s->power_down_flag = FALSE;
 }
 


### PR DESCRIPTION
This commit updates the cosim support for interrupts by checking
for a pending dut interrupt alongwith the MIP/MIE checks. Some
microarchitectures can delay the handling of interrupts and without
the proposed changes the cosim will diverge.

This commit also generalizes the CLINT read/write to allow byte or
half-word or word accesses (e.g. MSIP accesses)