### PR TITLE
Add support to check mmio address sets for cosim

### DIFF
--- a/src/machine.h
+++ b/src/machine.h
@@ -107,6 +107,11 @@ typedef struct {
     EthernetDevice *net;
 } VMEthEntry;
 
+typedef struct AddressSet{
+    uint64_t start;
+    uint64_t size;
+} AddressSet;
+
 typedef struct {
     char *cfg_filename;
     uint64_t ram_base_addr;
@@ -150,6 +155,8 @@ typedef struct {
     /* MMIO range (for co-simulation only) */
     uint64_t mmio_start;
     uint64_t mmio_end;
+    AddressSet *mmio_addrset;
+    uint64_t mmio_addrset_size;
 
     /* PLIC/CLINT Params */
     uint64_t plic_base_addr;

--- a/src/riscv_machine.h
+++ b/src/riscv_machine.h
@@ -84,6 +84,8 @@ struct RISCVMachine {
     /* MMIO range (for co-simulation only) */
     uint64_t mmio_start;
     uint64_t mmio_end;
+    AddressSet *mmio_addrset;
+    uint64_t mmio_addrset_size;
 
     /* Reset vector */
     uint64_t reset_vector;


### PR DESCRIPTION
This is required as mmio address space can be disjoint, should be represented by an address set and not a range alone. 

NOTE: I am not changing the existing checks for mmio range as other users might be affected. The mmio address set can only be specified via a config file.

Here is an example config file:

```
  {
    version:1,
    machine:"riscv64",
    memory_size:1024,
    bios:"program.bin",
    memory_base_addr:0x80000000,
    mmio_addrset:[
      {start:0x2000000,size:0x10000},
      {start:0xc000000,size:0x4000000}
    ]
  }
```