### PR TITLE
Fixes to get linux booting.

### DIFF
--- a/src/dromajo_cosim.cpp
+++ b/src/dromajo_cosim.cpp
@@ -40,6 +40,7 @@ dromajo_cosim_state_t *dromajo_cosim_init(int argc, char *argv[])
     m->llc = new LiveCache("LLC", 1024*32); // Small 32KB for testing
 #endif
 
+    m->common.cosim = true;
     m->common.pending_interrupt = -1;
     m->common.pending_exception = -1;
 

--- a/src/dromajo_template.h
+++ b/src/dromajo_template.h
@@ -262,7 +262,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles)
     insn_counter_addend = s->insn_counter + n_cycles;
 
     /* check pending interrupts */
-    if (unlikely(((s->mip & s->mie) != 0) && (s->machine->common.pending_interrupt != -1))) {
+    if (unlikely(((s->mip & s->mie) != 0) && (s->machine->common.pending_interrupt != -1 || !s->machine->common.cosim))) {
         if (raise_interrupt(s)) {
             --insn_counter_addend;
             goto done_interp;
@@ -307,7 +307,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles)
             target_ulong addr;
 
             /* check pending interrupts */
-            if (unlikely(((s->mip & s->mie) != 0) && (s->machine->common.pending_interrupt != -1))) {
+            if (unlikely(((s->mip & s->mie) != 0) && (s->machine->common.pending_interrupt != -1 || !s->machine->common.cosim))) {
                 if (raise_interrupt(s)) {
                     goto the_end;
                 }
@@ -1436,7 +1436,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles)
                         goto illegal_insn;
                     /* go to power down if no enabled interrupts are
                        pending */
-                    if (((s->mip & s->mie) == 0) && (s->machine->common.pending_interrupt == -1)) {
+                    if (((s->mip & s->mie) == 0) && (s->machine->common.pending_interrupt == -1) || !s->machine->common.cosim) {
                         s->power_down_flag = TRUE;
                         s->pc = GET_PC() + 4;
                         goto done_interp;

--- a/src/machine.h
+++ b/src/machine.h
@@ -190,6 +190,7 @@ typedef struct VirtMachine {
     uint64_t    trace;
 
     /* For co-simulation only, they are -1 if nothing is pending. */
+    bool        cosim;
     int         pending_interrupt;
     int         pending_exception;
 } VirtMachine;

--- a/src/riscv_cpu.cpp
+++ b/src/riscv_cpu.cpp
@@ -1851,7 +1851,7 @@ void riscv_cpu_set_mip(RISCVCPUState *s, uint32_t mask)
 {
     s->mip |= mask;
     /* exit from power down if an interrupt is pending */
-    if (s->power_down_flag && (s->mip & s->mie) != 0 && (s->machine->common.pending_interrupt != -1))
+    if (s->power_down_flag && (s->mip & s->mie) != 0 && (s->machine->common.pending_interrupt != -1 || !s->machine->common.cosim))
         s->power_down_flag = FALSE;
 }
 

--- a/src/riscv_machine.cpp
+++ b/src/riscv_machine.cpp
@@ -249,13 +249,13 @@ static uint32_t clint_read(void *opaque, uint32_t offset, int size_log2)
 #endif
 
     switch (size_log2) {
-        case DEVIO_SIZE8:
-            val = val & 0xff;
-            break;
-        case DEVIO_SIZE16:
+        case 1:
             val = val & 0xffff;
             break;
-        case DEVIO_SIZE32:
+        case 2:
+            val = val & 0xffffffff;
+            break;
+        case 3:
         default:
             break;
     }
@@ -269,13 +269,13 @@ static void clint_write(void *opaque, uint32_t offset, uint32_t val,
     RISCVMachine *m = (RISCVMachine *)opaque;
 
     switch (size_log2) {
-        case DEVIO_SIZE8:
-            val = val & 0xff;
-            break;
-        case DEVIO_SIZE16:
+        case 1:
             val = val & 0xffff;
             break;
-        case DEVIO_SIZE32:
+        case 2:
+            val = val & 0xffffffff;
+            break;
+        case 3:
         default:
             break;
     }
@@ -1096,6 +1096,11 @@ RISCVMachine *virt_machine_init(const VirtMachineParams *p)
     /* add custom extension bit to misa */
     s->custom_extension = p->custom_extension;
 
+    s->plic_base_addr  = p->plic_base_addr;
+    s->plic_size       = p->plic_size;
+    s->clint_base_addr = p->clint_base_addr;
+    s->clint_size      = p->clint_size;
+
     if (MAX_CPUS < s->ncpus) {
         fprintf(stderr, "ERROR: ncpus:%d exceeds maximum MAX_CPU\n", s->ncpus);
         exit(3);
@@ -1236,6 +1241,7 @@ RISCVMachine *virt_machine_init(const VirtMachineParams *p)
     s->mmio_addrset_size = p->mmio_addrset_size;
 
     /* interrupts and exception setup for cosim */
+    s->common.cosim = false;
     s->common.pending_exception = -1;
     s->common.pending_interrupt = -1;
 


### PR DESCRIPTION
This commit fixes the interrupt handling in cosim vs. standalone mode.
And also handles the clint reads/writes correctly. 
Also, passes plic/clint parameters into dtb properly

Linux is now booting.

- Adds a "cosim" boolean that only checks the dut raised interrupts in cosim mode
and otherwise ignores the dut marked pending interrupt checks.
- Fixes the masks used for clint reads and writes.