### PR TITLE
clang-format proposal and patch to allow re-org includes

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,20 @@
+---
+BasedOnStyle: Google
+ColumnLimit: '132'
+AlignConsecutiveAssignments: 'true'
+AlignConsecutiveDeclarations: 'true'
+#AlignConsecutiveBitFields: 'true'
+AlignConsecutiveMacros: 'true'
+AlignTrailingComments: 'true'
+AlignEscapedNewlines: 'true'
+AlignAfterOpenBracket: 'Align'
+AlignOperands: 'true'
+AllowAllArgumentsOnNextLine: 'false'
+BinPackArguments: 'false'
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'true'
+BreakConstructorInitializers: 'BeforeComma'
+BreakBeforeBinaryOperators: 'true'
+BreakStringLiterals: 'true'
+AccessModifierOffset: -2
+...

--- a/src/fs.h
+++ b/src/fs.h
@@ -38,6 +38,8 @@
  * THE SOFTWARE.
  */
 
+#include <cstdint>
+
 /* FSQID.type */
 #define P9_QTDIR 0x80
 #define P9_QTAPPEND 0x40


### PR DESCRIPTION
I committed a src/.clang-format with a uniform style suggestion for dromajo.

I did not run the clang-format, but to run it.
cd src
clang-format -i *.h *.cpp
git diff .

The small include patch is to allow reorg the includes by name (clang-format does it)

I think that it is a clean format style, and it will make the code more uniform.