### PR TITLE
Post-CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,52 @@
-cmake_minimum_required(VERSION 3.18.1)
+#
+# Dromajo, a RISC-V Emulator (based on Fabrice Bellard's RISCVEMU/TinyEMU)
+#
+# Copyright (c) 2016-2017 Fabrice Bellard
+# Copyright (c) 2018,2019,2020 Esperanto Technology
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# THIS FILE IS BASED ON RISCVEMU SOURCE CODE WHICH IS DISTRIBUTED UNDER
+# THE FOLLOWING LICENSE:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+cmake_minimum_required(VERSION 2.8)
 set(CMAKE_CXX_STANDARD 11)
 project(dromajo)
 option(TRACEOS "TRACEOS" OFF)
 option(SIMPOINT "SIMPOINT" OFF)
 
 add_compile_options(
+        -Ofast
+        -std=c++11
         -Wall
         -Wno-parentheses
         -MMD

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -17,7 +17,7 @@ cd ..
 To run one of the benchmarks with trace enabled
 
 ```
-../src/dromajo --trace 0 riscv-tests-root/share/riscv-tests/isa/rv64ua-p-amoadd_d
+../build/dromajo --trace 0 riscv-tests-root/share/riscv-tests/isa/rv64ua-p-amoadd_d
 ```
 
 ## Linux with buildroot
@@ -70,13 +70,13 @@ cd ..
 cp buildroot-2020.05.1/output/images/rootfs.cpio .
 cp linux-5.8-rc4/arch/riscv/boot/Image .
 cp opensbi/build/platform/generic/firmware/fw_jump.bin .
-../src/dromajo boot.cfg
+../build/dromajo boot.cfg
 ```
 
 ### To boot a quad-core RISC-V CPU
 
 ```
-../src/dromajo --ncpus 4 boot.cfg
+../build/dromajo --ncpus 4 boot.cfg
 ```
 
 ### Create and run checkpoints
@@ -92,7 +92,7 @@ It allows to create Linux boot checkpoints. E.g:
 Run 1M instructions and create a checkpoint from a Linux+openSBI boot:
 
 ```
-../src/dromajo --save ck1 --maxinsn 2000000 ./boot.cfg
+../build/dromajo --save ck1 --maxinsn 2000000 ./boot.cfg
 
 OpenSBI v0.7-39-g7be75f5
    ____                    _____ ____ _____
@@ -130,7 +130,7 @@ The ck1.bootram is the new bootram needed to recover the state.
 To continue booting Linux:
 
 ```
-../src/dromajo --load ck1 ./boot.cfg
+../build/dromajo --load ck1 ./boot.cfg
 [    0.000000] OF: fdt: Ignoring memory range 0x80000000 - 0x80200000
 [    0.000000] Linux version 5.7.0-rc4 (anup@anup-ubuntu64) (gcc version 9.2.0 (GCC), GNU ld (GNU Binutils) 2.32) #1 SMP Fri May 8 10:04:14 IST 2020
 [    0.000000] earlycon: sbi0 at I/O port 0x0 (options '')

--- a/doc/simpoint.md
+++ b/doc/simpoint.md
@@ -59,7 +59,7 @@ Dromajo will generate a dromajo_simpoint.bb trace for your execution
 
 ```
 cd run
-../src/dromajo ./boot.cfg
+../build/dromajo ./boot.cfg
 ```
 
 The simpoint_size constant at dromajo.cpp sets the simpoint size. Make sure
@@ -109,7 +109,7 @@ checkpoints have the same size of simpoint_size.
 ```
 
 ```
-../src/dromajo --simpoint simpoints ./boot.cfg
+../build/dromajo --simpoint simpoints ./boot.cfg
 ```
 
 
@@ -120,7 +120,7 @@ Given the previous example and simpoint_size of 1M instructions, to create
 the sp01 (89 1 entry), run dromajo:
 
 ```
-../src/dromajo --save sp01 --maxinsn 89000000 ./boot.cfg
+../build/dromajo --save sp01 --maxinsn 89000000 ./boot.cfg
 ```
 
 Repeat the checkpoint creation for each simpoint, and they are ready.
@@ -140,7 +140,7 @@ the checkpoint and execute only for the simpoint_size selected (1M in this
 example).
 
 ```
-../src/dromajo --load sp01 --maxinsn 1000000 ./boot.cfg
+../build/dromajo --load sp01 --maxinsn 1000000 ./boot.cfg
 ```
 
 Congratulations, You run your first dromajo simpoint created checkpoint!


### PR DESCRIPTION
- The Copyright notice was left out

- Important build flags were left out

- The cmake_minimum_required were set much too high; CentOS 7 doesn't
  appear to have newer than version 2.8.12.2 and there doesn't appear to
  a reason for requiring anything newer.

- The docs/*md needed to be patched to account for the src -> build change