### PR TITLE
Bootrom and UART improvements

### DIFF
--- a/bootrom/Makefile
+++ b/bootrom/Makefile
@@ -1,0 +1,36 @@
+#******************************************************************************
+# Copyright (C) 2018,2019,2020, Esperanto Technologies Inc.
+# The copyright to the computer program(s) herein is the
+# property of Esperanto Technologies, Inc. All Rights Reserved.
+# The program(s) may be used and/or copied only with
+# the written permission of Esperanto Technologies and
+# in accordance with the terms and conditions stipulated in the
+# agreement/contract under which the program(s) have been supplied.
+#------------------------------------------------------------------------------
+
+# RISCV environment variable must be set
+
+MEMORY_START=0x8000000000
+build_dir=.
+CC=$(RISCV)/bin/riscv64-unknown-elf-gcc
+OBJCOPY=$(RISCV)/bin/riscv64-unknown-elf-objcopy
+CFLAGS=-march=rv64gc -mabi=lp64 -O2 -std=gnu11 -Wall -I. -nostartfiles -fno-common -g -DMEMORY_START=$(MEMORY_START)
+LFLAGS=-static -nostdlib -Ttext=10000
+
+elf := $(build_dir)/bootrom.elf
+$(elf): bootrom.S
+	$(CC) $(CFLAGS) $(LFLAGS) -o $@ $<
+
+.PHONY: elf
+elf: $(elf)
+
+bin := $(build_dir)/bootrom.bin
+$(bin): $(elf)
+	$(OBJCOPY) -O binary $< $@
+
+.PHONY: bin
+bin: $(bin)
+
+.PHONY: clean
+clean::
+	rm -rf $(hex) $(elf)

--- a/bootrom/bootrom.S
+++ b/bootrom/bootrom.S
@@ -1,0 +1,37 @@
+//******************************************************************************
+// Copyright (C) 2018,2019, Esperanto Technologies Inc.
+// The copyright to the computer program(s) herein is the
+// property of Esperanto Technologies, Inc. All Rights Reserved.
+// The program(s) may be used and/or copied only with
+// the written permission of Esperanto Technologies and
+// in accordance with the terms and conditions stipulated in the
+// agreement/contract under which the program(s) have been supplied.
+//------------------------------------------------------------------------------
+
+//========================================================================
+// cosim bootrom
+//========================================================================
+// BootROM code used for the purposes of cosimulation.  Currently, the RTL
+// implementation includes a cosimulation configuration which sets the
+// processor in debug mode.  The bootrom code essentially sets the debug
+// pc and the debug csr register values accordingly to reset the processor
+// to the start of the test programs.
+
+        .section .text.init
+        .option  norvc
+        .globl   _start
+
+_start: csrr     a0, mhartid
+        beqz     a0, 1f           // We only allow hart0 to proceed
+
+0:      wfi
+        j        0b
+
+1:      la       a1, _start + 256 // DTB is at boot start + 256
+
+        li       s0, 0x603
+        csrw     dcsr, s0
+
+        li       s0, MEMORY_START // Start kernel and exit debug
+        csrw     dpc, s0
+        dret

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -32,7 +32,7 @@ to just build it. The libc library setup is muslc.
 wget https://github.com/buildroot/buildroot/archive/2020.05.1.tar.gz
 tar xvf 2020.05.1.tar.gz
 cp config-buildroot-2020.05.1 buildroot-2020.05.1/.config
-make -j16 -C buildroot-2020.05.1
+make -j$(nproc) -C buildroot-2020.05.1
 ```
 
 ### Get the Linux kernel up and running (~ 3 min)

--- a/include/machine.h
+++ b/include/machine.h
@@ -157,12 +157,12 @@ typedef struct {
     uint64_t maxinsns;
 
     /* snapshot load file */
-    const char *snapshot_load_name;
+    char *snapshot_load_name;
 
     /* bootrom params */
-    const char *bootrom_name;
-    const char *dtb_name;
-    bool        compact_bootrom;
+    char *bootrom_name;
+    char *dtb_name;
+    bool  compact_bootrom;
 
     /* reset vector used at startup */
     uint64_t reset_vector;
@@ -206,11 +206,11 @@ typedef struct VirtMachine {
     std::vector<Simpoint> simpoints;
 #endif
 
-    const char *snapshot_load_name;
-    const char *snapshot_save_name;
-    const char *terminate_event;
-    uint64_t    maxinsns;
-    uint64_t    trace;
+    char *   snapshot_load_name;
+    char *   snapshot_save_name;
+    char *   terminate_event;
+    uint64_t maxinsns;
+    uint64_t trace;
 
     /* For co-simulation only, they are -1 if nothing is pending. */
     bool cosim;

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -601,8 +601,8 @@ static bool load_elf_and_fake_the_config(VirtMachineParams *p, const char *path)
 
 RISCVMachine *virt_machine_main(int argc, char **argv) {
     const char *prog                     = argv[0];
-    const char *snapshot_load_name       = 0;
-    const char *snapshot_save_name       = 0;
+    char *      snapshot_load_name       = 0;
+    char *      snapshot_save_name       = 0;
     const char *path                     = NULL;
     const char *cmdline                  = NULL;
     long        ncpus                    = 0;
@@ -612,8 +612,8 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
     uint64_t    memory_addr_override     = 0;
     bool        ignore_sbi_shutdown      = false;
     bool        dump_memories            = false;
-    const char *bootrom_name             = 0;
-    const char *dtb_name                 = 0;
+    char *      bootrom_name             = 0;
+    char *      dtb_name                 = 0;
     bool        compact_bootrom          = false;
     uint64_t    reset_vector_override    = 0;
     uint64_t    mmio_start_override      = 0;

--- a/src/riscv_machine.cpp
+++ b/src/riscv_machine.cpp
@@ -784,6 +784,7 @@ static int riscv_build_fdt(RISCVMachine *m, uint8_t *dst, const char *dtb_name, 
         {
             fdt_prop_str(s, "compatible", "ns16550");
             fdt_prop_tab_u64_2(s, "reg", DW_APB_UART0_BASE_ADDR, DW_APB_UART0_SIZE);
+            fdt_prop_u32(s, "clock-frequency", 3686400);  // Arbitrary, just to stop complaining
             fdt_prop_u32(s, "reg-shift", 2);
             fdt_prop_u32(s, "reg-io-width", 4);
             // No interrupts?


### PR DESCRIPTION
Misc accumulated improvements.  Officially deprecates reliance on the auto generated bootrom and include a simple example of make to make one + adds support for giving it in the config file.

META COMMENT: please do not add command line options without a corresponding option for the config file, unless inappropriate.  Dromajo has a fair amount of technical debt, but piling on my command line options is the wrong direction.  We need to refactor it further to where it can be included as a library.