### PR TITLE
support K,M,G for instruction count and documentation format issue

### DIFF
--- a/doc/simpoint.md
+++ b/doc/simpoint.md
@@ -153,6 +153,7 @@ omitting clock ticks for idle CPUs, but it still has a timer interrupt when 1 si
 For benchmarking (or HPC), it is common to disable the timer interrupt also if there is only one running thread.
 This can be done by changing the "Timer subsystem" options in the linux configuration. For Linux kernel 5.7:
 
+```
 #
 # Timers subsystem
 #
@@ -166,6 +167,7 @@ CONFIG_CONTEXT_TRACKING=y
 # CONFIG_NO_HZ is not set
 CONFIG_HIGH_RES_TIMERS=y
 # end of Timers subsystem
+```
 
 
 ## Locate the most different simpoints

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -696,6 +696,15 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
                 if (maxinsns)
                     usage(prog, "already had a max instructions");
                 maxinsns = (uint64_t)atoll(optarg);
+                {
+                  char last=optarg[strlen(optarg)-1];
+                  if (last=='k' || last=='K')
+                    maxinsns *= 1000;
+                  else if (last=='m' || last=='M')
+                    maxinsns *= 1000000;
+                  else if (last=='g' || last=='G')
+                    maxinsns *= 1000000000;
+                }
                 break;
 
             case 't':


### PR DESCRIPTION
Minor changes to improve the documentation and allow to have K,M,G for maxinsns. E.g: `--maxinsns 100M`