### PR TITLE
add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: cpp
+
+compiler:
+  - clang++
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release ..
+
+script:
+  - make


### PR DESCRIPTION
ADD Travis CI for testing the build. It is a simple build test.

After merging, the administrator(s) of this repo should have a [Travis](https://www.travis-ci.org/) account and add this repo in their account to trigger the build. 