### PR TITLE
adding support for saving checkpoint in ELF format

### DIFF
--- a/include/machine.h
+++ b/include/machine.h
@@ -190,6 +190,7 @@ typedef struct {
     char *logfile;  // If non-zero, all output goes here, stderr and stdout
 
     bool dump_memories;
+    BOOL is_snapshot_elf; // for saving snapshot mainram/bootrom in ELF 
 } VirtMachineParams;
 
 typedef struct VirtMachine {

--- a/include/riscv_cpu.h
+++ b/include/riscv_cpu.h
@@ -305,7 +305,7 @@ int riscv_benchmark_exit_code(RISCVCPUState *s);
 
 #include "riscv_machine.h"
 void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t clint_base_addr);
-void riscv_cpu_deserialize(RISCVCPUState *s, const char *dump_name);
+void riscv_cpu_deserialize(RISCVCPUState *s, const char *dump_name, bool is_elf);
 
 int riscv_cpu_read_memory(RISCVCPUState *s, mem_uint_t *pval, target_ulong addr, int size_log2);
 int riscv_cpu_write_memory(RISCVCPUState *s, target_ulong addr, mem_uint_t val, int size_log2);

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -603,6 +603,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
     const char *prog                     = argv[0];
     char *      snapshot_load_name       = 0;
     char *      snapshot_save_name       = 0;
+    char * 	snapshot_load_name_elf   = 0;  // elf-support
     const char *path                     = NULL;
     const char *cmdline                  = NULL;
     long        ncpus                    = 0;
@@ -638,6 +639,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
             {"ncpus",                   required_argument, 0,  'n' }, // CFG
             {"load",                    required_argument, 0,  'l' },
             {"save",                    required_argument, 0,  's' },
+            {"loadelf",                 required_argument, 0,  'e' }, //elf-support
             {"simpoint",                required_argument, 0,  'S' },
             {"maxinsns",                required_argument, 0,  'm' }, // CFG
             {"trace   ",                required_argument, 0,  't' },
@@ -677,6 +679,12 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
             case 'l':
                 if (snapshot_load_name)
                     usage(prog, "already had a snapshot to load");
+                snapshot_load_name = strdup(optarg);
+                break;
+
+            case 'e':   // elf-support
+                if (snapshot_load_name_elf)
+                    usage(prog, "already had a snapshot to load elf");
                 snapshot_load_name = strdup(optarg);
                 break;
 
@@ -1023,7 +1031,8 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
         s->common.net->device_set_carrier(s->common.net, TRUE);
 
     if (s->common.snapshot_load_name)
-        virt_machine_deserialize(s, s->common.snapshot_load_name);
+        virt_machine_deserialize(s, s->common.snapshot_load_name, 
+                                    s->common.is_snapshot_elf); // elf-support
 
     return s;
 }

--- a/src/riscv_machine.cpp
+++ b/src/riscv_machine.cpp
@@ -1051,6 +1051,7 @@ RISCVMachine *virt_machine_init(const VirtMachineParams *p) {
     s->common.maxinsns                = p->maxinsns;
     s->common.snapshot_load_name      = p->snapshot_load_name;
 
+    s->common.is_snapshot_elf         = p->is_snapshot_elf; // elf-support
     s->ncpus = p->ncpus;
 
     /* setup reset vector for core
@@ -1278,11 +1279,12 @@ void virt_machine_serialize(RISCVMachine *m, const char *dump_name) {
     riscv_cpu_serialize(s, dump_name, m->clint_base_addr);
 }
 
-void virt_machine_deserialize(RISCVMachine *m, const char *dump_name) {
+// adding elf-support is_elf is true when reading elf file
+void virt_machine_deserialize(RISCVMachine *m, const char *dump_name, bool is_elf){
     RISCVCPUState *s = m->cpu_state[0];  // FIXME: MULTICORE
 
     assert(m->ncpus == 1);  // FIXME: riscv_cpu_serialize must be patched for multicore
-    riscv_cpu_deserialize(s, dump_name);
+    riscv_cpu_deserialize(s, dump_name, is_elf);
 }
 
 int virt_machine_get_sleep_duration(RISCVMachine *m, int hartid, int ms_delay) {


### PR DESCRIPTION
This is work-in-progress. I will appreciate your feedback. 
The ELF checkpoint support comprises:
1. creating elf checkpoint 
    When "dromajo --save <file>"  is run, the elf file name <file>-elf is created.
    Bootrom and Mainram are added to ELF .text and .data section respectively.
2. loading the elf checkpoint using keyword "loadelf" 
    dromajo --loadelf <file> --maxinsns=2000000 boot.cfg 
3. During loading the elf file, riscv_cpu_deserialize reads the ELF sections and copies the respective data into the physical memory range 
4. Using ELFIO C++ headers library for creating sections, and reading when using loadelf keyword
