### PR TITLE
Optimize ctz

### DIFF
--- a/include/cutils.h
+++ b/include/cutils.h
@@ -149,15 +149,39 @@ static inline uint32_t cpu_to_be32(uint32_t v) { return v; }
 static inline uint32_t cpu_to_be32(uint32_t v) { return bswap_32(v); }
 #endif
 
-static inline int ctz32(uint32_t a) {
-    int i;
-    if (a == 0)
-        return 32;
-    for (i = 0; i < 32; i++) {
-        if ((a >> i) & 1)
-            return i;
+static inline int ctz32(uint32_t val)
+{
+#if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+    return val ? __builtin_ctz(val) : 32;
+#else
+    /* Binary search for the trailing one bit.  */
+    int cnt;
+    cnt = 0;
+    if (!(val & 0x0000FFFFUL)) {
+        cnt += 16;
+        val >>= 16;
     }
-    return 32;
+    if (!(val & 0x000000FFUL)) {
+        cnt += 8;
+        val >>= 8;
+    }
+    if (!(val & 0x0000000FUL)) {
+        cnt += 4;
+        val >>= 4;
+    }
+    if (!(val & 0x00000003UL)) {
+        cnt += 2;
+        val >>= 2;
+    }
+    if (!(val & 0x00000001UL)) {
+        cnt++;
+        val >>= 1;
+    }
+    if (!(val & 0x00000001UL)) {
+        cnt++;
+    }
+    return cnt;
+#endif
 }
 
 void *mallocz(size_t size);


### PR DESCRIPTION
Use intrinsic `ctz` for bitcounting. While `ctz` is not available, use
branchless implementation instead.