### PR TITLE
Ebreak should not be cancelled under cosim mode

### DIFF
--- a/include/dromajo_template.h
+++ b/include/dromajo_template.h
@@ -1663,7 +1663,8 @@ mmu_exception:
 exception:
     s->pc = GET_PC();
     if (s->pending_exception >= 0) {
-        if (s->pending_exception < CAUSE_USER_ECALL || s->pending_exception > CAUSE_USER_ECALL + 3) {
+        if ((s->pending_exception < CAUSE_USER_ECALL || s->pending_exception > CAUSE_USER_ECALL + 3) &&
+             s->pending_exception != CAUSE_BREAKPOINT) {
             /* All other causes cancelled the instruction and shouldn't be
              * counted in minstret */
             --insn_counter_addend;


### PR DESCRIPTION
I found that dromajo-cosim cancels ebreak in the except handle function, which causes dromajo-cosim to execute 2 instructions in a single step.
```
# main dromajo
0 1 0x0000000080000190 (0x00200193) x 3 0x0000000000000002
0 1 0x0000000080000194 (0x00100073) exception 3, tval 0000000000000000
0 1 0x00000000800001d0 (0x00300313) x 6 0x0000000000000003

# dromajo cosim
1 0x0000000080000190 (0x00200193) x3  0x0000000000000002 DASM(0x00200193)
1 0x00000000800001d0 (0x00300313) x6  0x0000000000000003 DASM(0x00300313)
```