### PR TITLE
Speed up general execution by ~ 20X

### DIFF
--- a/include/machine.h
+++ b/include/machine.h
@@ -257,7 +257,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv);
 void          virt_machine_end(RISCVMachine *s);
 void          virt_machine_serialize(RISCVMachine *m, const char *dump_name);
 void          virt_machine_deserialize(RISCVMachine *m, const char *dump_name);
-BOOL          virt_machine_run(RISCVMachine *m, int hartid);
+BOOL          virt_machine_run(RISCVMachine *m, int hartid, int n_cycles);
 uint64_t      virt_machine_get_pc(RISCVMachine *m, int hartid);
 uint64_t      virt_machine_get_reg(RISCVMachine *m, int hartid, int rn);
 uint64_t      virt_machine_get_fpreg(RISCVMachine *m, int hartid, int rn);

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -489,10 +489,10 @@ static EthernetDevice *slirp_open(void) {
 
 #endif /* CONFIG_SLIRP */
 
-BOOL virt_machine_run(RISCVMachine *s, int hartid) {
+BOOL virt_machine_run(RISCVMachine *s, int hartid, int n_cycles) {
     (void)virt_machine_get_sleep_duration(s, hartid, MAX_SLEEP_TIME);
 
-    riscv_cpu_interp64(s->cpu_state[hartid], 1);
+    riscv_cpu_interp64(s->cpu_state[hartid], n_cycles);
     RISCVCPUState *cpu = s->cpu_state[hartid];
     if (s->htif_tohost_addr) {
         uint32_t tohost;


### PR DESCRIPTION
Unless we are tracing or cosimulating, we should run for a long as possible inside riscv_cpu_interp64().  This change speeds up normal execution by a large amount.