### PR TITLE
Speed up + bootram + track dropped load/stores

### DIFF
--- a/include/machine.h
+++ b/include/machine.h
@@ -257,7 +257,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv);
 void          virt_machine_end(RISCVMachine *s);
 void          virt_machine_serialize(RISCVMachine *m, const char *dump_name);
 void          virt_machine_deserialize(RISCVMachine *m, const char *dump_name);
-BOOL          virt_machine_run(RISCVMachine *m, int hartid);
+BOOL          virt_machine_run(RISCVMachine *m, int hartid, int n_cycles);
 uint64_t      virt_machine_get_pc(RISCVMachine *m, int hartid);
 uint64_t      virt_machine_get_reg(RISCVMachine *m, int hartid, int rn);
 uint64_t      virt_machine_get_fpreg(RISCVMachine *m, int hartid, int rn);

--- a/include/riscv_cpu.h
+++ b/include/riscv_cpu.h
@@ -44,7 +44,7 @@
 
 #include "riscv.h"
 
-#define ROM_SIZE       0x00001000
+#define ROM_SIZE       0x00002000
 #define ROM_BASE_ADDR  0x00010000
 #define BOOT_BASE_ADDR 0x00010000
 

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -121,8 +121,10 @@ int simpoint_step(RISCVMachine *m, int hartid) {
 }
 #endif
 
-int iterate_core(RISCVMachine *m, int hartid) {
-    if (m->common.maxinsns-- <= 0)
+static int iterate_core(RISCVMachine *m, int hartid, int n_cycles) {
+    m->common.maxinsns -= n_cycles;
+
+    if (m->common.maxinsns <= 0)
         /* Succeed after N instructions without failure. */
         return 0;
 
@@ -134,13 +136,18 @@ int iterate_core(RISCVMachine *m, int hartid) {
     uint64_t last_pc  = virt_machine_get_pc(m, hartid);
     int      priv     = riscv_get_priv_level(cpu);
     uint32_t insn_raw = -1;
-    (void)riscv_read_insn(cpu, &insn_raw, last_pc);
-    int keep_going = virt_machine_run(m, hartid);
-    if (last_pc == virt_machine_get_pc(m, hartid))
-        return 0;
+    bool     do_trace = false;
 
-    if (m->common.trace) {
-        --m->common.trace;
+    (void)riscv_read_insn(cpu, &insn_raw, last_pc);
+    if (m->common.trace < (unsigned) n_cycles) {
+        n_cycles = 1;
+        do_trace = true;
+    } else
+      m->common.trace -= n_cycles;
+
+    int keep_going = virt_machine_run(m, hartid, n_cycles);
+
+    if (!do_trace) {
         return keep_going;
     }
 
@@ -216,6 +223,7 @@ int main(int argc, char **argv) {
     if (!m)
         return 1;
 
+    int n_cycles = 10000;
     execution_start_ts = get_current_time_in_seconds();
     execution_progress_meassure = &m->cpu_state[0]->minstret;
     signal(SIGINT, sigintr_handler);
@@ -223,7 +231,7 @@ int main(int argc, char **argv) {
     int keep_going;
     do {
         keep_going = 0;
-        for (int i = 0; i < m->ncpus; ++i) keep_going |= iterate_core(m, i);
+        for (int i = 0; i < m->ncpus; ++i) keep_going |= iterate_core(m, i, n_cycles);
 #ifdef SIMPOINT_BB
         if (simpoint_roi) {
             if (!simpoint_step(m, 0))

--- a/src/dromajo_main.cpp
+++ b/src/dromajo_main.cpp
@@ -489,10 +489,10 @@ static EthernetDevice *slirp_open(void) {
 
 #endif /* CONFIG_SLIRP */
 
-BOOL virt_machine_run(RISCVMachine *s, int hartid) {
+BOOL virt_machine_run(RISCVMachine *s, int hartid, int n_cycles) {
     (void)virt_machine_get_sleep_duration(s, hartid, MAX_SLEEP_TIME);
 
-    riscv_cpu_interp64(s->cpu_state[hartid], 1);
+    riscv_cpu_interp64(s->cpu_state[hartid], n_cycles);
     RISCVCPUState *cpu = s->cpu_state[hartid];
     if (s->htif_tohost_addr) {
         uint32_t tohost;


### PR DESCRIPTION
The speed up change restores [most of?] the performance of original RISCVEMU by cache the ITLB lookups.  This breaks cosim of course which is why we ran without it, but for non-cosim runs it nice to have it back.

The bootram was mistakenly set to 4 KiB (yes, this needs to be configurable)

Adding a warning tracking for loads/stores that go to memory that isn't tracked (eg. MMIO)