### PR TITLE
Fix #64 track memory sequence numbers

### DIFF
--- a/include/riscv_cpu.h
+++ b/include/riscv_cpu.h
@@ -290,7 +290,17 @@ typedef struct RISCVCPUState {
 
     uint32_t plic_enable_irq[2];
 
+    /*
+     * "The SC must fail if a store to the reservation set from
+     * another hart can be observed to occur between the LR and SC."
+     *
+     * To achieve this in a scalable and low-overhead way we maintain
+     * a sequence number for global memory and one per reservation.
+     * As long as the reservation tracks the global number, we know no
+     * other hart has written memory.
+     */
     target_ulong load_res; /* for atomic LR/SC */
+    uint64_t     load_res_memseqno;
 
     PhysMemoryMap *mem_map;
     int            physical_addr_len;

--- a/include/riscv_machine.h
+++ b/include/riscv_machine.h
@@ -65,6 +65,14 @@ struct RISCVMachine {
     LiveCache *llc;
 #endif
     RISCVCPUState *cpu_state[MAX_CPUS];
+
+    /*
+     * Each write to memory increases the memseqno.  We use this to
+     * enable SC to invalidate a load reservation if memory has been
+     * written by an external agent (including another hart).
+     */
+    uint64_t memseqno;
+
     int            ncpus;
     uint64_t       ram_size;
     uint64_t       ram_base_addr;

--- a/run/Makefile
+++ b/run/Makefile
@@ -1,0 +1,6 @@
+laur-repro: laur
+	../build/dromajo --ctrlc --ncpus=4 laur
+
+laur: laur.S
+	riscv64-unknown-elf-gcc -march=rv64g -mabi=lp64 -static -mcmodel=medany -nostdlib -nostartfiles \
+		laur.S -lgcc -T test.ld -o laur

--- a/run/laur.S
+++ b/run/laur.S
@@ -1,0 +1,237 @@
+# See LICENSE for license details.
+
+//#include "encoding.h"
+#define MSTATUS_XS          0x00018000
+#define MSTATUS_FS          0x00006000
+#define MSTATUS_MPP         0x00001800
+
+#if __riscv_xlen == 64
+# define LREG ld
+# define SREG sd
+# define REGBYTES 8
+#else
+# define LREG lw
+# define SREG sw
+# define REGBYTES 4
+#endif
+
+  .section ".text.init"
+  .globl _start
+_start:
+  li  x1, 0
+  li  x2, 0
+  li  x3, 0
+  li  x4, 0
+  li  x5, 0
+  li  x6, 0
+  li  x7, 0
+  li  x8, 0
+  li  x9, 0
+  li  x10,0
+  li  x11,0
+  li  x12,0
+  li  x13,0
+  li  x14,0
+  li  x15,0
+  li  x16,0
+  li  x17,0
+  li  x18,0
+  li  x19,0
+  li  x20,0
+  li  x21,0
+  li  x22,0
+  li  x23,0
+  li  x24,0
+  li  x25,0
+  li  x26,0
+  li  x27,0
+  li  x28,0
+  li  x29,0
+  li  x30,0
+  li  x31,0
+
+  # enable FPU and accelerator if present
+  li t0, MSTATUS_FS | MSTATUS_XS
+  csrs mstatus, t0
+
+  # make sure XLEN agrees with compilation choice
+  li t0, 1
+  slli t0, t0, 31
+#if __riscv_xlen == 64
+  bgez t0, 1f
+#else
+  bltz t0, 1f
+#endif
+2:
+  li a0, 1
+  sw a0, tohost, t0
+  j 2b
+1:
+
+#ifdef __riscv_flen
+  # initialize FPU if we have one
+  la t0, 1f
+  csrw mtvec, t0
+
+  fssr    x0
+  fmv.s.x f0, x0
+  fmv.s.x f1, x0
+  fmv.s.x f2, x0
+  fmv.s.x f3, x0
+  fmv.s.x f4, x0
+  fmv.s.x f5, x0
+  fmv.s.x f6, x0
+  fmv.s.x f7, x0
+  fmv.s.x f8, x0
+  fmv.s.x f9, x0
+  fmv.s.x f10,x0
+  fmv.s.x f11,x0
+  fmv.s.x f12,x0
+  fmv.s.x f13,x0
+  fmv.s.x f14,x0
+  fmv.s.x f15,x0
+  fmv.s.x f16,x0
+  fmv.s.x f17,x0
+  fmv.s.x f18,x0
+  fmv.s.x f19,x0
+  fmv.s.x f20,x0
+  fmv.s.x f21,x0
+  fmv.s.x f22,x0
+  fmv.s.x f23,x0
+  fmv.s.x f24,x0
+  fmv.s.x f25,x0
+  fmv.s.x f26,x0
+  fmv.s.x f27,x0
+  fmv.s.x f28,x0
+  fmv.s.x f29,x0
+  fmv.s.x f30,x0
+  fmv.s.x f31,x0
+1:
+#endif
+
+  # initialize trap vector
+  la t0, trap_entry
+  csrw mtvec, t0
+
+  # initialize global pointer
+.option push
+.option norelax
+  la gp, __global_pointer$
+.option pop
+
+  la  tp, _end + 63
+  and tp, tp, -64
+
+  # get core id
+  csrr a0, mhartid
+  # laur: run on all cores
+#  li a1, 1
+#1:bgeu a0, a1, 1b
+
+  # give each core 128KB of stack + TLS
+#define STKSHIFT 17
+  add sp, a0, 1
+  sll sp, sp, STKSHIFT
+  add sp, sp, tp
+  sll a2, a0, STKSHIFT
+  add tp, tp, a2
+
+#  j _init
+
+  # laur
+  # have each core add 1 to tohost
+  la a1, tohost
+1: lr.w a4, (a1)
+addi a4, a4, 1
+sc.w a4, a4, (a1)
+bnez a4, 1b
+label1:j label1
+
+  .align 2
+trap_entry:
+  addi sp, sp, -272
+
+  SREG x1, 1*REGBYTES(sp)
+  SREG x2, 2*REGBYTES(sp)
+  SREG x3, 3*REGBYTES(sp)
+  SREG x4, 4*REGBYTES(sp)
+  SREG x5, 5*REGBYTES(sp)
+  SREG x6, 6*REGBYTES(sp)
+  SREG x7, 7*REGBYTES(sp)
+  SREG x8, 8*REGBYTES(sp)
+  SREG x9, 9*REGBYTES(sp)
+  SREG x10, 10*REGBYTES(sp)
+  SREG x11, 11*REGBYTES(sp)
+  SREG x12, 12*REGBYTES(sp)
+  SREG x13, 13*REGBYTES(sp)
+  SREG x14, 14*REGBYTES(sp)
+  SREG x15, 15*REGBYTES(sp)
+  SREG x16, 16*REGBYTES(sp)
+  SREG x17, 17*REGBYTES(sp)
+  SREG x18, 18*REGBYTES(sp)
+  SREG x19, 19*REGBYTES(sp)
+  SREG x20, 20*REGBYTES(sp)
+  SREG x21, 21*REGBYTES(sp)
+  SREG x22, 22*REGBYTES(sp)
+  SREG x23, 23*REGBYTES(sp)
+  SREG x24, 24*REGBYTES(sp)
+  SREG x25, 25*REGBYTES(sp)
+  SREG x26, 26*REGBYTES(sp)
+  SREG x27, 27*REGBYTES(sp)
+  SREG x28, 28*REGBYTES(sp)
+  SREG x29, 29*REGBYTES(sp)
+  SREG x30, 30*REGBYTES(sp)
+  SREG x31, 31*REGBYTES(sp)
+
+  csrr a0, mcause
+  csrr a1, mepc
+  mv a2, sp
+  # jal handle_trap
+  csrw mepc, a0
+
+  # Remain in M-mode after eret
+  li t0, MSTATUS_MPP
+  csrs mstatus, t0
+
+  LREG x1, 1*REGBYTES(sp)
+  LREG x2, 2*REGBYTES(sp)
+  LREG x3, 3*REGBYTES(sp)
+  LREG x4, 4*REGBYTES(sp)
+  LREG x5, 5*REGBYTES(sp)
+  LREG x6, 6*REGBYTES(sp)
+  LREG x7, 7*REGBYTES(sp)
+  LREG x8, 8*REGBYTES(sp)
+  LREG x9, 9*REGBYTES(sp)
+  LREG x10, 10*REGBYTES(sp)
+  LREG x11, 11*REGBYTES(sp)
+  LREG x12, 12*REGBYTES(sp)
+  LREG x13, 13*REGBYTES(sp)
+  LREG x14, 14*REGBYTES(sp)
+  LREG x15, 15*REGBYTES(sp)
+  LREG x16, 16*REGBYTES(sp)
+  LREG x17, 17*REGBYTES(sp)
+  LREG x18, 18*REGBYTES(sp)
+  LREG x19, 19*REGBYTES(sp)
+  LREG x20, 20*REGBYTES(sp)
+  LREG x21, 21*REGBYTES(sp)
+  LREG x22, 22*REGBYTES(sp)
+  LREG x23, 23*REGBYTES(sp)
+  LREG x24, 24*REGBYTES(sp)
+  LREG x25, 25*REGBYTES(sp)
+  LREG x26, 26*REGBYTES(sp)
+  LREG x27, 27*REGBYTES(sp)
+  LREG x28, 28*REGBYTES(sp)
+  LREG x29, 29*REGBYTES(sp)
+  LREG x30, 30*REGBYTES(sp)
+  LREG x31, 31*REGBYTES(sp)
+
+  addi sp, sp, 272
+  mret
+
+.section ".tohost","aw",@progbits
+.align 6
+.globl tohost
+tohost: .dword 0
+.align 6
+.globl fromhost
+fromhost: .dword 0


### PR DESCRIPTION
Stores may invalidate reservations held by other harts.  I tried to find the cheapest possible implementation of this and settled on store sequence numbers.  Stores increment the global and the local reservation sequence numbers so they will stay in sync as long as no other hart stores before the store conditional.

Using the test case provided by Laurentiu-Cristian Duca, and changing Dromajo to execute only a single instruction per hart per iteration, we can observe that reservations are broken as expected:
```
0: lr.w: addr=80001000, S#0
1: lr.w: addr=80001000, S#0
2: lr.w: addr=80001000, S#0
3: lr.w: addr=80001000, S#0
0: sc.w success memval=1 S#0
1: sc.w failed memval=1 S#0 != S#1
2: sc.w failed memval=1 S#0 != S#1
3: sc.w failed memval=1 S#0 != S#1
```

It's still slightly more expensive than I like.  Two possible variations:
- a global reservation_count and putting all the accounting inside a `if (unlikely(s->machine_resv_count)) {`
- nuking the tlb translation for pages with reservations and only handle the accounting inside the slow path.