### PR TITLE
Fixing issue #73

### DIFF
--- a/include/machine.h
+++ b/include/machine.h
@@ -151,7 +151,7 @@ typedef struct {
     VMFileEntry files[VM_FILE_COUNT];
 
     /* maximum increment of instructions to execute */
-    uint64_t maxinsns;
+    int64_t maxinsns;
 
     /* snapshot load file */
     char *snapshot_load_name;
@@ -203,7 +203,7 @@ typedef struct VirtMachine {
     char *   snapshot_load_name;
     char *   snapshot_save_name;
     char *   terminate_event;
-    uint64_t maxinsns;
+    int64_t maxinsns;
     uint64_t trace;
 
     /* For co-simulation only, they are -1 if nothing is pending. */

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -233,7 +233,7 @@ static int virt_machine_parse_config(VirtMachineParams *p, char *config_file_str
     }
 
     vm_get_uint64_opt(cfg, "htif_base_addr", &p->htif_base_addr);
-    vm_get_uint64_opt(cfg, "maxinsns", &p->maxinsns);
+    vm_get_int(cfg, "maxinsns", &p->maxinsns);
 
     if (vm_get_str_opt(cfg, "load", &p->snapshot_load_name) < 0)
         goto tag_fail;


### PR DESCRIPTION
Small patch to fix issue #73. 
Decided to keep `maxinsns` common for all cores, i.e. per simulation, rather than per core.