### PR TITLE
Fixing issues #73 and #75

### DIFF
--- a/include/machine.h
+++ b/include/machine.h
@@ -151,7 +151,7 @@ typedef struct {
     VMFileEntry files[VM_FILE_COUNT];
 
     /* maximum increment of instructions to execute */
-    uint64_t maxinsns;
+    int64_t maxinsns;
 
     /* snapshot load file */
     char *snapshot_load_name;
@@ -203,7 +203,7 @@ typedef struct VirtMachine {
     char *   snapshot_load_name;
     char *   snapshot_save_name;
     char *   terminate_event;
-    uint64_t maxinsns;
+    int64_t maxinsns;
     uint64_t trace;
 
     /* For co-simulation only, they are -1 if nothing is pending. */

--- a/include/riscv_cpu.h
+++ b/include/riscv_cpu.h
@@ -363,7 +363,9 @@ void riscv_set_debug_mode(RISCVCPUState *s, bool on);
 int riscv_benchmark_exit_code(RISCVCPUState *s);
 
 #include "riscv_machine.h"
+void riscv_ram_serialize(RISCVCPUState *s, const char *dump_name);
 void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t clint_base_addr);
+void riscv_ram_deserialize(RISCVCPUState *s, const char *dump_name);
 void riscv_cpu_deserialize(RISCVCPUState *s, const char *dump_name);
 
 int riscv_cpu_read_memory(RISCVCPUState *s, mem_uint_t *pval, target_ulong addr, int size_log2);

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -233,7 +233,7 @@ static int virt_machine_parse_config(VirtMachineParams *p, char *config_file_str
     }
 
     vm_get_uint64_opt(cfg, "htif_base_addr", &p->htif_base_addr);
-    vm_get_uint64_opt(cfg, "maxinsns", &p->maxinsns);
+    vm_get_int(cfg, "maxinsns", &p->maxinsns);
 
     if (vm_get_str_opt(cfg, "load", &p->snapshot_load_name) < 0)
         goto tag_fail;

--- a/src/riscv_cpu.cpp
+++ b/src/riscv_cpu.cpp
@@ -2680,6 +2680,27 @@ static void create_boot_rom(RISCVCPUState *s, const char *file, const uint64_t c
     serialize_memory(rom, ROM_SIZE, file);
 }
 
+void riscv_ram_serialize(RISCVCPUState *s, const char *dump_name) {
+    bool is_ram_found = false;
+    for (int i = s->mem_map->n_phys_mem_range - 1; i >= 0; --i) {
+        PhysMemoryRange *pr = &s->mem_map->phys_mem_range[i];
+        if (pr->is_ram && pr->addr == s->machine->ram_base_addr) {
+            assert(!is_ram_found);
+            is_ram_found = true;
+
+            char *f_name = (char *)alloca(strlen(dump_name) + 64);
+            sprintf(f_name, "%s.mainram", dump_name);
+
+            serialize_memory(pr->phys_mem, pr->size, f_name);
+        }
+    }
+
+    if (!is_ram_found) {
+        fprintf(dromajo_stderr, "ERROR: could not find main RAM.\n");
+        exit(-3);
+    }
+}
+
 void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t clint_base_addr) {
     FILE * conf_fd   = 0;
     size_t n         = strlen(dump_name) + 64;
@@ -2739,9 +2760,7 @@ void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t
     for (int i = 0; i < 4; i += 2) fprintf(conf_fd, "pmpcfg%d:%llx\n", i, (unsigned long long)s->csr_pmpcfg[i]);
     for (int i = 0; i < 16; ++i) fprintf(conf_fd, "pmpaddr%d:%llx\n", i, (unsigned long long)s->csr_pmpaddr[i]);
 
-    PhysMemoryRange *boot_ram       = 0;
-    int              main_ram_found = 0;
-
+    PhysMemoryRange *boot_ram = 0;
     for (int i = s->mem_map->n_phys_mem_range - 1; i >= 0; --i) {
         PhysMemoryRange *pr = &s->mem_map->phys_mem_range[i];
         fprintf(conf_fd, "mrange%d:0x%llx 0x%llx %s\n", i, (long long)pr->addr, (long long)pr->size, pr->is_ram ? "ram" : "io");
@@ -2749,20 +2768,11 @@ void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t
         if (pr->is_ram && pr->addr == ROM_BASE_ADDR) {
             assert(!boot_ram);
             boot_ram = pr;
-
-        } else if (pr->is_ram && pr->addr == s->machine->ram_base_addr) {
-            assert(!main_ram_found);
-            main_ram_found = 1;
-
-            char *f_name = (char *)alloca(strlen(dump_name) + 64);
-            sprintf(f_name, "%s.mainram", dump_name);
-
-            serialize_memory(pr->phys_mem, pr->size, f_name);
-        }
+        } 
     }
 
-    if (!boot_ram || !main_ram_found) {
-        fprintf(dromajo_stderr, "ERROR: could not find boot and main ram???\n");
+    if (!boot_ram) {
+        fprintf(dromajo_stderr, "ERROR: could not find boot RAM.\n");
         exit(-3);
     }
 
@@ -2771,17 +2781,30 @@ void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t
     snprintf(f_name, n, "%s.bootram", dump_name);
 
     if (s->priv != 3 || ROM_BASE_ADDR + ROM_SIZE < s->pc) {
-        fprintf(dromajo_stderr, "NOTE: creating a new boot rom\n");
+        fprintf(dromajo_stderr, "NOTE: creating a new boot ROM.\n");
         create_boot_rom(s, f_name, clint_base_addr);
     } else if (BOOT_BASE_ADDR < s->pc) {
-        fprintf(dromajo_stderr, "ERROR: could not checkpoint when running inside the ROM\n");
+        fprintf(dromajo_stderr, "ERROR: could not checkpoint when running inside the ROM.\n");
         exit(-4);
     } else if (s->pc == BOOT_BASE_ADDR && boot_ram) {
-        fprintf(dromajo_stderr, "NOTE: using the default dromajo ROM\n");
+        fprintf(dromajo_stderr, "NOTE: using the default dromajo ROM.\n");
         serialize_memory(boot_ram->phys_mem, boot_ram->size, f_name);
     } else {
-        fprintf(dromajo_stderr, "ERROR: unexpected PC address 0x%llx\n", (long long)s->pc);
+        fprintf(dromajo_stderr, "ERROR: unexpected PC address 0x%llx.\n", (long long)s->pc);
         exit(-4);
+    }
+}
+
+void riscv_ram_deserialize(RISCVCPUState *s, const char *dump_name) {
+    for (int i = s->mem_map->n_phys_mem_range - 1; i >= 0; --i) {
+        PhysMemoryRange *pr = &s->mem_map->phys_mem_range[i];
+        if (pr->is_ram && pr->addr == s->machine->ram_base_addr) {
+            size_t n         = strlen(dump_name) + 64;
+            char * main_name = (char *)alloca(n);
+            snprintf(main_name, n, "%s.mainram", dump_name);
+
+            deserialize_memory(pr->phys_mem, pr->size, main_name);
+        }
     }
 }
 
@@ -2795,13 +2818,6 @@ void riscv_cpu_deserialize(RISCVCPUState *s, const char *dump_name) {
             snprintf(boot_name, n, "%s.bootram", dump_name);
 
             deserialize_memory(pr->phys_mem, pr->size, boot_name);
-
-        } else if (pr->is_ram && pr->addr == s->machine->ram_base_addr) {
-            size_t n         = strlen(dump_name) + 64;
-            char * main_name = (char *)alloca(n);
-            snprintf(main_name, n, "%s.mainram", dump_name);
-
-            deserialize_memory(pr->phys_mem, pr->size, main_name);
-        }
+        } 
     }
 }

--- a/src/riscv_machine.cpp
+++ b/src/riscv_machine.cpp
@@ -51,6 +51,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <err.h>
+#include <sstream>
 
 #include "cutils.h"
 #include "dromajo.h"
@@ -1415,19 +1416,35 @@ void virt_machine_end(RISCVMachine *s) {
 }
 
 void virt_machine_serialize(RISCVMachine *m, const char *dump_name) {
-    RISCVCPUState *s = m->cpu_state[0];  // FIXME: MULTICORE
+    /* Serialize core states. */
+    for (int i = 0; i < m->ncpus; ++i) {
+        RISCVCPUState *s = m->cpu_state[i];
 
-    vm_error("plic: %x %x timecmp=%llx\n", m->plic_pending_irq, m->plic_served_irq, (unsigned long long)s->timecmp);
+        vm_error("plic: %x %x timecmp=%llx\n", m->plic_pending_irq, m->plic_served_irq, (unsigned long long)s->timecmp);
 
-    assert(m->ncpus == 1);  // FIXME: riscv_cpu_serialize must be patched for multicore
-    riscv_cpu_serialize(s, dump_name, m->clint_base_addr);
+        /* Append core number suffix to the file name. */
+        std::stringstream core_dump_name;
+        core_dump_name << dump_name << i;
+        riscv_cpu_serialize(s, core_dump_name.str().c_str(), m->clint_base_addr);
+    }
+
+    /* Serialize memory. */
+    riscv_ram_serialize(m->cpu_state[0], dump_name);
 }
 
 void virt_machine_deserialize(RISCVMachine *m, const char *dump_name) {
-    RISCVCPUState *s = m->cpu_state[0];  // FIXME: MULTICORE
+    /* Deserialize core states. */
+    for (int i = 0; i < m->ncpus; ++i) {
+        RISCVCPUState *s = m->cpu_state[i];
 
-    assert(m->ncpus == 1);  // FIXME: riscv_cpu_serialize must be patched for multicore
-    riscv_cpu_deserialize(s, dump_name);
+        /* Append core number suffix to the file name. */
+        std::stringstream core_dump_name;
+        core_dump_name << dump_name << i;
+        riscv_cpu_deserialize(s, core_dump_name.str().c_str());
+    }
+
+    /* Deserialize memory. */
+    riscv_ram_deserialize(m->cpu_state[0], dump_name);
 }
 
 int virt_machine_get_sleep_duration(RISCVMachine *m, int hartid, int ms_delay) {


### PR DESCRIPTION
@tommythorn, @renau, I would appreciate your comments 😊

## Overview
This PR addresses issues #73 and #75.

Issue 73 is fixed simply by changing the type of `maxinsns` variable from unsigned to signed. This ensures the variable does not overflow when 0 is decremented.

Issue 75 is fixed by placing the serialization functions into loop and dumping the register state per core (n register states). The main memory is dumped per system (one memory dump). Same is done for deserialization logic.

## Try it out
To test the feature try the following:

```bash
./dromajo --maxinsns 1000000 --ncpus 2 --trace 0 [multicore-bin.riscv] --save snapshots/multicore
```

After the execution completes, the following files should be generated in the `snapshots` directory:

```
.
├── shared_mem_conf.mainram
├── shared_mem_conf0.bootram
├── shared_mem_conf0.re_regs
├── shared_mem_conf1.bootram
└── shared_mem_conf1.re_regs
```

As you can see, `*.bootram` dumps get generated per core and `*.mainram` is still a single file.

To proceed the simulation from the checkpoint, create the following json config file in the `snapshots` directory, let's name it `multicore_conf.json`:

```json
{
  "version":1,
  "machine":"riscv64",
  "bios": "[absolute-path-to-bin-dir/multicore-bin.riscv]",
  "load": "[absolute-path-to-dromajo-repo]/build/snapshots/multicore",
  "memory_base_addr": 0x80000000,
  "maxinsns": 1000000000,
  "ncpus": 2,
  "memory_size":256,
  "clint_base_addr": 0x02000000,
  "clint_size": 0xC0000,
  "plic_base_addr": 0x0C000000,
  "plic_size": 0x3FFFFFF,
  "uart_base_addr": 0x10000000,
  "uart_size": 0x1000
}
```

Finally, run dromajo again pointing it to the config file:

```bash
./dromajo --trace 0 ./snapshots/multicore_conf.json
```

The simulation should proceed from the checkpoint.
