### PR TITLE
Summary: creating single boot ROM for multicore configs

### DIFF
--- a/include/riscv_cpu.h
+++ b/include/riscv_cpu.h
@@ -46,7 +46,7 @@
 
 #define ROM_SIZE       0x00002000
 #define ROM_BASE_ADDR  0x00010000
-#define BOOT_BASE_ADDR 0x00010000
+#define BOOT_BASE_ADDR 0x00010040
 
 // The default RAM base, can be relocated with config "memory_base_addr"
 #define RAM_BASE_ADDR 0x80000000
@@ -363,6 +363,8 @@ void riscv_set_debug_mode(RISCVCPUState *s, bool on);
 int riscv_benchmark_exit_code(RISCVCPUState *s);
 
 #include "riscv_machine.h"
+void generate_core_boot_rom(uint32_t *rom, uint32_t rom_size, uint32_t code_pos, uint32_t data_pos, RISCVCPUState *s, const uint64_t clint_base_addr);
+void create_boot_rom_image(uint32_t *rom, uint32_t rom_size_bytes, const char *file_name);
 void riscv_ram_serialize(RISCVCPUState *s, const char *dump_name);
 void riscv_cpu_serialize(RISCVCPUState *s, const char *dump_name, const uint64_t clint_base_addr);
 void riscv_ram_deserialize(RISCVCPUState *s, const char *dump_name);

--- a/src/dromajo.cpp
+++ b/src/dromajo.cpp
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
     if (!m)
         return 1;
 
-    int n_cycles = 10000;
+    int n_cycles = 1;
     execution_start_ts = get_current_time_in_seconds();
     execution_progress_meassure = &m->cpu_state[0]->minstret;
     signal(SIGINT, sigintr_handler);


### PR DESCRIPTION
The motive for this PR is explained in #79.

This pull request introduces the implementation for the enhancement. When the checkpoint is saved, a single boot ROM is generated for N cores. The boot code is divided into N sections, where N represents the number of cores. Each core will generate its own recovery code and write it to its designated section. In addition to the recovery code, each core initializes with a preamble code that reads the hart_id and calculates the program counter (PC) based on the id.

Please let me know what you think.