### PR TITLE
Checkpoints: Add checkpointing infrastructure for devices

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -41,6 +41,7 @@
 #define JSON_H
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include "cutils.h"
 
@@ -135,8 +136,11 @@ static inline JSONValue json_bool_new(BOOL v) {
 
 const char *json_get_str(JSONValue val);
 const char *json_get_error(JSONValue val);
+int64_t     json_get_int64(JSONValue val);
 
 JSONValue json_parse_value(const char *p);
 JSONValue json_parse_value_len(const char *p, int len);
+
+int json_write(JSONValue val, FILE *fd, int indent);
 
 #endif /* JSON_H */

--- a/include/riscv_machine.h
+++ b/include/riscv_machine.h
@@ -49,6 +49,7 @@
 #endif
 
 #define MAX_CPUS 8
+#define MAX_VIOS MAX_ETH_DEVICE + MAX_DRIVE_DEVICE + 3
 
 /* Hooks */
 typedef struct RISCVMachineHooks {
@@ -77,6 +78,7 @@ struct RISCVMachine {
     uint64_t ram_size;
     uint64_t ram_base_addr;
     /* PLIC */
+    uint32_t  plic_priority[PLIC_NUM_SOURCES + 1];
     uint32_t  plic_pending_irq;
     uint32_t  plic_served_irq;
     IRQSignal plic_irq[32]; /* IRQ 0 is not used */
@@ -84,6 +86,7 @@ struct RISCVMachine {
     /* HTIF */
     uint64_t htif_tohost_addr;
 
+    VIRTIODevice *virtio_devices[MAX_VIOS];
     VIRTIODevice *keyboard_dev;
     VIRTIODevice *mouse_dev;
 

--- a/include/virtio.h
+++ b/include/virtio.h
@@ -42,6 +42,7 @@
 
 #include "cutils.h"
 #include "iomem.h"
+#include "json.h"
 #include "pci.h"
 
 #define VIRTIO_PAGE_SIZE 4096
@@ -134,5 +135,9 @@ VIRTIODevice *virtio_input_init(VIRTIOBusDef *bus, VirtioInputTypeEnum type);
 #include "fs.h"
 
 VIRTIODevice *virtio_9p_init(VIRTIOBusDef *bus, FSDevice *fs, const char *mount_tag);
+
+void virtio_device_serialize(VIRTIODevice *s, JSONValue vio_device);
+
+void virtio_device_deserialize(VIRTIODevice *s, JSONValue vio_device);
 
 #endif /* VIRTIO_H */


### PR DESCRIPTION
- Extend the JSON library slightly to support writing out JSON trees
- Add support in riscv_machine to dump the PLIC state and virtio device state as a JSON that can be read back in to restore it
- Not all device state is stored yet, but this is enough to boot linux, checkpoint, restore from the checkpoint and then use the virtio filesystem. Which is handy.