### PR TITLE
Forward mallocz to calloc.

### DIFF
--- a/include/cutils.h
+++ b/include/cutils.h
@@ -96,7 +96,9 @@ static inline int min_int(int a, int b) {
         return b;
 }
 
-void *mallocz(size_t size);
+static inline void *mallocz(size_t size) {
+    return calloc(size, 1);
+}
 
 #if defined(__APPLE__)
 static inline uint32_t bswap_32(uint32_t v) {

--- a/src/cutils.cpp
+++ b/src/cutils.cpp
@@ -48,15 +48,6 @@
 #include <string.h>
 #include <sys/time.h>
 
-void *mallocz(size_t size) {
-    void *ptr;
-    ptr = malloc(size);
-    if (!ptr)
-        return NULL;
-    memset(ptr, 0, size);
-    return ptr;
-}
-
 void pstrcpy(char *buf, int buf_size, const char *str) {
     int   c;
     char *q = buf;


### PR DESCRIPTION
This can be more efficient on OSes that maintain a zero'd page list.